### PR TITLE
docs: ADR-000 — Arvo system identity and architectural invariants (AAM 1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ Arvo abstracts infrastructure concerns from your business logic. Write applicati
 
 The same primitives work for simple request-response services, complex multi-service workflows, AI agent systems, and everything in between. No framework lock-in, no mandatory infrastructure, just clean event-driven code that integrates with your existing stack.
 
+For the thesis behind this — what Arvo is betting on, and how that bet could turn out to be wrong — see [the Arvo vision document](docs/vision.md). The binding architectural commitments are recorded in [ADR-000](docs/adr/000-arvo-system-identity-and-architectural-principles.md).
+
 ## What is `arvo-core`?
 
 The `arvo-core` is one of the two foundational packages in the Arvo ecosystem, alongside `arvo-event-handler`. Together, they provide the complete foundation for building event-driven applications that are distributed system-compliant. Explore additional tools and integrations in the `@arvo-tools` namespace.

--- a/docs/adr/000-arvo-system-identity-and-architectural-principles.md
+++ b/docs/adr/000-arvo-system-identity-and-architectural-principles.md
@@ -305,6 +305,25 @@ The following require dedicated ADRs or specifications:
 - Security and trust integration
 - Cross-language protocol compatibility
 
+## Applying This ADR
+
+Every downstream ADR must state:
+
+- what it adds to, refines, or excludes from the portable application model;
+- which invariants it depends on or strains;
+- what it requires of infrastructure adapters;
+- what it leaves deferred.
+
+The membership lists in **Portable application model** are exhaustive as of this ADR. A downstream ADR that places a new concern inside or outside the model amends those lists by explicit reference. Concerns listed under **Deferred Decisions** have undetermined membership until the relevant ADR decides it; their absence from the lists is not exclusion.
+
+### Standing Constraints
+
+Deferred decisions must preserve the following:
+
+- Node identity must not become the durable key for anything a boundary refactor would invalidate, including lineage records, persisted handler state, and external correlation. Reversible composition depends on this.
+- Execution capability profiles must compose, because a sealed node's profile derives from the profiles of its members.
+- Contract compatibility rules determine how much internal change a sealed boundary can absorb, and therefore whether reversible composition holds in practice.
+
 ## Governance
 
 Accepted ADRs and feature specifications must conform to this decision. A later decision that conflicts with this ADR must identify the conflict explicitly and supersede the affected principle or this ADR as a whole.

--- a/docs/adr/000-arvo-system-identity-and-architectural-principles.md
+++ b/docs/adr/000-arvo-system-identity-and-architectural-principles.md
@@ -92,7 +92,9 @@ The presence of a contract does not guarantee that a participating implementatio
 
 The exact execution, state, suspension, resumption, concurrency, and recovery semantics are defined in dedicated ArvoEventHandler ADRs.
 
-## Architectural Principles
+## Invariants
+
+These are normative. Changing one is an architectural change and requires a superseding ADR.
 
 ### Infrastructure Independence
 
@@ -126,12 +128,6 @@ Nodes compose through explicit, versioned contracts. The portable application mo
 
 Dedicated ADRs define the validation boundaries and failure representations. Compile-time type safety should be provided as strongly as practical, but it does not replace runtime validation and must not prevent future cross-language participation.
 
-### Standards-Based Interoperability
-
-Arvo uses established standards where they provide suitable semantics. ArvoEvent supports transformation into a CloudEvent for interoperability while remaining an independent JSON-serializable event model.
-
-Arvo is TypeScript-first, with future support for other languages. TypeScript implementation details must not unnecessarily become protocol requirements.
-
 ### Observability by Default
 
 The portable application model must preserve sufficient correlation, causation, lineage, and trace context to make distributed composition observable.
@@ -147,6 +143,16 @@ Arvo distinguishes among:
 - Infrastructure and delivery failures
 
 Detailed failure representations and recovery semantics are deferred to dedicated ADRs.
+
+## Project Values
+
+These describe current project policy. They may evolve without superseding this ADR and are not requirements for Arvo conformance.
+
+### Standards-Based Interoperability
+
+Arvo uses established standards where they provide suitable semantics rather than defining new ones. The CloudEvent transformation described under ArvoEvent is one instance.
+
+Arvo is TypeScript-first, with future support for other languages. The project avoids letting TypeScript implementation details become requirements of the portable application model; cross-language compatibility is addressed in a dedicated ADR.
 
 ### Developer Experience
 

--- a/docs/adr/000-arvo-system-identity-and-architectural-principles.md
+++ b/docs/adr/000-arvo-system-identity-and-architectural-principles.md
@@ -1,6 +1,6 @@
 # ADR-000: Arvo System Identity and Architectural Invariants
 
-- **Status:** Proposed
+- **Status:** Accepted
 - **Date:** 2026-07-31
 - **Scope:** Arvo ecosystem
 - **Defines:** Arvo Application Model (AAM) 1

--- a/docs/adr/000-arvo-system-identity-and-architectural-principles.md
+++ b/docs/adr/000-arvo-system-identity-and-architectural-principles.md
@@ -36,8 +36,9 @@ An Arvo application is understood conceptually as a dynamic graph of independent
 - **Implementation dependency:** A database, API, library, model provider, or other resource used internally by a node without participating in the portable application model.
 - **Handler:** An application-layer implementation of an Arvo node. An ArvoEventHandler implements one ArvoContract, declares its ArvoContract dependencies, and may continue its logical execution across multiple event deliveries and infrastructure executions.
 - **Infrastructure adapter:** An integration that binds Arvo's portable application model to execution, delivery, persistence, scheduling, discovery, or other infrastructure.
-- **Arvo Application Model (AAM):** The versioned, language-independent model defined by this ADR and its descendants. AAM versions are distinct from the versions of any package implementing them. `arvo-core` v4 is the first TypeScript implementation of AAM 1.
-- **Portable application model:** The ArvoEvent identities and data; ArvoContract identities, versions, and declared event capabilities; inter-node interactions; causation, lineage, and trace context; handler interfaces and lifecycle semantics; execution capability requirements; validation and compatibility semantics; and failure categories whose meaning must remain consistent across supporting infrastructure adapters. It excludes physical transport, persistence technology, scheduling implementation, retry counts, batching, telemetry collection and export, and handler implementation dependencies.
+- **Arvo Application Model (AAM):** Arvo's versioned, language-independent portable application model, defined by this ADR and its descendants. It comprises the ArvoEvent identities and data; ArvoContract identities, versions, and declared event capabilities; inter-node interactions; causation, lineage, and trace context; handler interfaces and lifecycle semantics; execution capability requirements; validation and compatibility semantics; and failure categories whose meaning must remain consistent across supporting infrastructure adapters. It excludes physical transport, persistence technology, scheduling implementation, retry counts, batching, telemetry collection and export, and handler implementation dependencies. AAM versions are distinct from the versions of any package implementing them; `arvo-core` v4 is the first TypeScript implementation of AAM 1.
+
+  *AAM* is the formal name. *Portable application model* is used descriptively throughout this ADR and refers to the same thing.
 - **Execution slice:** One active period of handler execution, beginning when the handler receives or resumes from an event and ending when it completes, fails, or suspends while awaiting another event.
 - **Execution capability profile:** The declared runtime capabilities and constraints required to execute a handler. Its exact model is defined separately.
 
@@ -316,7 +317,7 @@ Every downstream ADR must state:
 - what it requires of infrastructure adapters;
 - what it leaves deferred.
 
-The membership lists in **Portable application model** are exhaustive as of this ADR. A downstream ADR that places a new concern inside or outside the model amends those lists by explicit reference. Concerns listed under **Deferred Decisions** have undetermined membership until the relevant ADR decides it; their absence from the lists is not exclusion.
+The membership lists in the **Arvo Application Model (AAM)** definition are exhaustive as of this ADR. A downstream ADR that places a new concern inside or outside the model amends those lists by explicit reference. Concerns listed under **Deferred Decisions** have undetermined membership until the relevant ADR decides it; their absence from the lists is not exclusion.
 
 ### Standing Constraints
 

--- a/docs/adr/000-arvo-system-identity-and-architectural-principles.md
+++ b/docs/adr/000-arvo-system-identity-and-architectural-principles.md
@@ -19,7 +19,7 @@ Arvo needs an application model in which these different participants can compos
 
 The motivating thesis, its failure conditions, and a worked example are described in [the Arvo vision document](../vision.md). This ADR records the resulting architectural commitments.
 
-This ADR establishes the identity and architectural principles of Arvo. It governs the Arvo ecosystem beyond a single package or major version. Arvo v4 is the first implementation expected to conform to it.
+This ADR establishes the identity and architectural principles of Arvo. It governs the Arvo ecosystem beyond a single package or major version, and defines the first version of the Arvo Application Model, AAM 1. `arvo-core` v4 is the first implementation expected to conform to it.
 
 ## Decision
 
@@ -36,6 +36,7 @@ An Arvo application is understood conceptually as a dynamic graph of independent
 - **Implementation dependency:** A database, API, library, model provider, or other resource used internally by a node without participating in the portable application model.
 - **Handler:** An application-layer implementation of an Arvo node. An ArvoEventHandler implements one ArvoContract, declares its ArvoContract dependencies, and may continue its logical execution across multiple event deliveries and infrastructure executions.
 - **Infrastructure adapter:** An integration that binds Arvo's portable application model to execution, delivery, persistence, scheduling, discovery, or other infrastructure.
+- **Arvo Application Model (AAM):** The versioned, language-independent model defined by this ADR and its descendants. AAM versions are distinct from the versions of any package implementing them. `arvo-core` v4 is the first TypeScript implementation of AAM 1.
 - **Portable application model:** The ArvoEvent identities and data; ArvoContract identities, versions, and declared event capabilities; inter-node interactions; causation and lineage; handler interfaces and lifecycle semantics; execution capability requirements; validation and compatibility semantics; and failure categories whose meaning must remain consistent across supporting infrastructure adapters. It excludes physical transport, persistence technology, scheduling implementation, retry counts, batching, telemetry collection and export, and handler implementation dependencies.
 - **Execution slice:** One active period of handler execution, beginning when the handler receives or resumes from an event and ending when it completes, fails, or suspends while awaiting another event.
 - **Execution capability profile:** The declared runtime capabilities and constraints required to execute a handler. Its exact model is defined separately.
@@ -330,4 +331,4 @@ Accepted ADRs and feature specifications must conform to this decision. A later 
 
 This repository is the canonical source of Arvo ecosystem ADRs until a dedicated architecture repository supersedes it. Ecosystem repositories must reference these records rather than maintain independent copies.
 
-This ADR should be marked **Accepted** only after review confirms that it accurately represents Arvo's enduring identity rather than the incidental details of its current TypeScript implementation.
+This ADR should be marked **Accepted** only after review confirms that it accurately describes the Arvo Application Model rather than the incidental details of any one implementation of it.

--- a/docs/adr/000-arvo-system-identity-and-architectural-principles.md
+++ b/docs/adr/000-arvo-system-identity-and-architectural-principles.md
@@ -1,297 +1,167 @@
-# ADR-000: Arvo System Identity and Architectural Principles
+# ADR-000: Arvo System Identity and Architectural Invariants
 
 - **Status:** Proposed
 - **Date:** 2026-07-31
 - **Scope:** Arvo ecosystem
-- **Decision owners:** Arvo maintainers
+- **Defines:** Arvo Application Model (AAM) 1
 
-## Conformance Language
-
-In this ADR, **must** denotes a requirement for Arvo conformance. **Should** denotes a recommendation that may be departed from with documented justification. **May** denotes a permitted choice.
+**must** is a requirement for Arvo conformance. **should** is a recommendation departable with documented justification. **may** is a permitted choice. Sections marked non-normative bind nothing.
 
 ## Context
 
-Modern durable execution and workflow platforms provide valuable operational capabilities, but they commonly require application workflows to conform to platform-specific execution models. These models may impose determinism, functional purity, centralized workflow ownership, or other constraints necessary for a particular platform's operation.
+Application logic has stopped being one kind of thing. A single business process now routinely spans deterministic code, a nondeterministic agent, a human who answers in three days, and an external system nobody controls. Operationally these have almost nothing in common — different latencies, different failure modes, different notions of correctness.
 
-Those constraints are useful within their intended environments, but they make application behaviour dependent on the selected engine. They also become restrictive when an application combines conventional handlers, deterministic workflows, imperative processes, nondeterministic workflows, AI agents, human participation, and external systems.
+Every available model makes one of them the first-class citizen and the rest exceptions. Durable execution platforms model deterministic workflows well and treat agents and humans as escapes from the model. Agent frameworks invert it. Plain choreography treats all participants equally and then offers no way to see or manage the process once it passes a few dozen nodes. So teams compose across paradigms — an engine here, a queue there, a task table for the humans — and the seams are where these systems actually fail.
 
-Arvo needs an application model in which these different participants can compose without requiring one execution engine to own the complete process. Arvo seeks to keep their composition and lifecycle semantics portable while infrastructure adapters and platforms perform execution, persistence, delivery, scheduling, and recovery according to their strengths.
+Boundaries also harden. Where a service boundary lands early is where it stays, because the service boundary is also the deployment boundary and the codebase boundary. Domain understanding arrives late, and by then moving a boundary costs a rewrite.
 
-The motivating thesis, its failure conditions, and a worked example are described in [the Arvo vision document](../vision.md). This ADR records the resulting architectural commitments.
+And whichever engine is adopted to solve the first problem, the application's composition semantics become that engine's semantics.
 
-This ADR establishes the identity and architectural principles of Arvo. It governs the Arvo ecosystem beyond a single package or major version, and defines the first version of the Arvo Application Model, AAM 1. `arvo-core` v4 is the first implementation expected to conform to it.
+Arvo needs a composition model that treats all of these participants as the same kind of thing, lets boundaries move as understanding improves, and encodes no single engine's execution model.
+
+The motivating thesis and the conditions under which it fails are set out in [the vision document](../vision.md). This ADR records the commitments that follow from it.
 
 ## Decision
 
-Arvo is a lightweight, opinionated framework that defines a portable application model for event-driven systems.
+Arvo is a portable, language-independent application model for event-driven systems. This ADR defines its first version, **AAM 1**. Arvo does not execute the model; infrastructure adapters do. Implementations of it, such as `arvo-core`, are lightweight and opinionated.
 
-Arvo does not execute that model itself and is not an orchestration engine or infrastructure runtime. It provides the protocol semantics, contracts, application primitives, and integration boundaries required to express event-driven application behaviour. Infrastructure adapters execute that behaviour and provide operational capabilities.
+An Arvo application is a dynamic graph of independently participating nodes. Nodes compose only through ArvoEvents governed by declared ArvoContracts. The graph emerges from contracts, participants, and emitted events; no participant needs to know it in full.
 
-An Arvo application is understood conceptually as a dynamic graph of independently participating nodes. Nodes compose exclusively through interactions represented by ArvoEvents and governed by declared ArvoContracts. The graph emerges from contracts, participating nodes, and emitted events; it does not require a complete central declaration or owner.
+Three claims answer the three problems above, and the rest of this ADR exists to support them.
+
+**Choreography is the universal composition model.** A node may be a handler, a deterministic workflow, an imperative or nondeterministic process, an AI agent, a human, or an external system reached through a declared contract boundary. None of them is an exception to the model. Orchestration is supported as *orchestrated choreography*: a coordinating node may direct or combine the work of others, but it remains an ordinary participant with no privileged, out-of-band control path.
+
+**Composition is closed.** Any set of composed nodes can itself be presented as a single node behind one ArvoContract. Composition and decomposition are both first-class and reversible — several nodes converge into one, one node bifurcates into several, as domain understanding, ownership, scaling, or reuse requires. Closure needs no additional primitive: a sealed subgraph is an ArvoEventHandler implementing the outer contract and declaring the inner contracts as dependencies, indistinguishable from any other node from outside. This is what allows choreography semantics to hold at any scale, and it makes node granularity a reversible design decision rather than an architectural commitment.
+
+Two limits follow. Declared event capabilities are boundary-local — one hop, not the transitive effects behind a sealed node. And reversibility is bounded: decomposition behind a boundary is invisible to callers, while convergence is invisible only where the absorbed contracts had no external consumers.
+
+**The model is portable.** Composition and handler lifecycle semantics must not depend on the broker, database, platform, scheduler, or engine an adapter selects. Portability of a handler's *internal* logic is not claimed; that depends on its runtime and its own dependencies.
 
 ## Terminology
 
-- **Node:** A conceptual participant in an Arvo application that exposes or consumes capabilities through Arvo contracts. A node may be implemented by an ArvoEventHandler, a human participant, or an external system.
-- **Inter-node interaction:** A request, signal, result, failure, or other exchange used to compose application behaviour between Arvo nodes.
-- **Implementation dependency:** A database, API, library, model provider, or other resource used internally by a node without participating in the portable application model.
-- **Handler:** An application-layer implementation of an Arvo node. An ArvoEventHandler implements one ArvoContract, declares its ArvoContract dependencies, and may continue its logical execution across multiple event deliveries and infrastructure executions.
-- **Infrastructure adapter:** An integration that binds Arvo's portable application model to execution, delivery, persistence, scheduling, discovery, or other infrastructure.
-- **Arvo Application Model (AAM):** Arvo's versioned, language-independent portable application model, defined by this ADR and its descendants. It comprises the ArvoEvent identities, data, and CloudEvent transformability; ArvoContract identities, versions, and declared event capabilities; inter-node interactions; causation, lineage, and trace context; handler interfaces and lifecycle semantics; execution capability requirements; validation and compatibility semantics; and failure categories whose meaning must remain consistent across supporting infrastructure adapters. It excludes physical transport, persistence technology, scheduling implementation, retry counts, batching, telemetry collection and export, and handler implementation dependencies. AAM versions are distinct from the versions of any package implementing them; `arvo-core` v4 is the first TypeScript implementation of AAM 1.
+- **Node** — a participant that exposes or consumes capabilities through Arvo contracts. A node may be implemented by an ArvoEventHandler, a human participant, an external system, or a composition of nodes presented behind a single contract.
+- **Handler** — an application-layer implementation of a node. An ArvoEventHandler implements one ArvoContract, declares its contract dependencies, and may continue its logical execution across multiple event deliveries and infrastructure executions.
+- **Implementation dependency** — a database, API, library, model provider, or other resource used internally by a node without participating in the model.
+- **Infrastructure adapter** — an integration binding the model to execution, delivery, persistence, scheduling, or discovery.
+- **Execution slice** — one active period of handler execution, from receiving or resuming on an event until the handler completes, fails, or suspends awaiting another.
+- **Execution capability profile** — the runtime capabilities a handler declares it requires. Its model is deferred.
 
-  *AAM* is the formal name. *Portable application model* is used descriptively throughout this ADR and refers to the same thing.
-- **Execution slice:** One active period of handler execution, beginning when the handler receives or resumes from an event and ending when it completes, fails, or suspends while awaiting another event.
-- **Execution capability profile:** The declared runtime capabilities and constraints required to execute a handler. Its exact model is defined separately.
+### Arvo Application Model (AAM)
 
-## Architectural Thesis
+Arvo's versioned, language-independent portable application model, defined by this ADR and its descendants. AAM versions are distinct from the versions of any package implementing them; `arvo-core` v4 is the first TypeScript implementation of AAM 1. *Portable application model* is used descriptively for the same thing.
 
-Application-layer choreography is Arvo's universal composition model.
+Inside the model — meaning must remain consistent across supporting adapters:
 
-A node may represent a simple handler, a deterministic workflow, an imperative or nondeterministic process, an AI agent, a human participant, or an external system. External participants may act as conceptual nodes through a declared ArvoContract boundary, but Arvo does not model or control their internals.
+- ArvoEvent identities, data, and CloudEvent transformability
+- ArvoContract identities, versions, and declared event capabilities
+- inter-node interactions
+- causation, lineage, and trace context
+- handler interfaces and lifecycle semantics
+- execution capability requirements
+- validation and compatibility semantics
+- failure categories
 
-Orchestration is supported as **orchestrated choreography**. A coordinating node may direct or combine the work of other nodes, but it remains an ordinary participant. It communicates through ArvoEvents governed by declared ArvoContracts and receives no privileged, out-of-band control path.
+Outside the model:
 
-Every inter-node interaction must be represented within the portable application model as an ArvoEvent. Physical transports and internal execution mechanisms may differ. Infrastructure adapters may use platform-native capabilities internally, including optimizations, provided they do not bypass or change the portable application model.
-
-### Composition Closure
-
-Composition is closed: any set of composed nodes can itself be presented as a single node behind one ArvoContract. Composition and decomposition are both first-class and reversible. Several nodes may converge into one, and one node may bifurcate into several, as domain understanding, ownership, scaling, or reuse requires. Arvo makes every boundary legal and prescribes none; where to place a node boundary is an application design decision.
-
-Closure is what allows choreography semantics to hold at any scale. The same composition model applies to a single handler, a coordinating node, and a sealed subgraph of arbitrary depth, so a growing system does not require a second paradigm at subsystem boundaries.
-
-Two limits follow. A handler's declared event capabilities are boundary-local: they describe one hop, not the transitive effects of everything behind a sealed node. And reversibility is bounded. Decomposition behind a sealed boundary is transparent to callers, while convergence is transparent only where no external participant addressed the inner contracts.
+- physical transport and protocol bindings
+- persistence technology and scheduling implementation
+- retry counts, batching, and other adapter-internal behaviour
+- telemetry collection, retention, and export
+- handler implementation dependencies
 
 ## Core Concepts
 
-Arvo is founded on three primary concepts.
+**ArvoEvent** — a JSON-serializable event exchanged between nodes. Every ArvoEvent must be transformable into a CloudEvent; transformability binds AAM 1, while whether the transformation is lossless and bidirectional is settled by the ArvoEvent ADR.
 
-### ArvoEvent
+**ArvoContract** — a versioned capability and interface declaration describing the events a node accepts and emits. It is the boundary through which independently implemented participants compose. It is not a registry, deployment descriptor, routing configuration, or implementation; discovery and routing belong to infrastructure.
 
-An ArvoEvent is a JSON-serializable event used for communication between Arvo nodes. Every ArvoEvent must be transformable into a CloudEvent for standards-based interoperability. Transformability is a binding capability of AAM 1; whether the transformation is lossless and bidirectional is determined by the ArvoEvent ADR.
+**ArvoEventHandler** — a resumable component that implements one contract, declares the contracts it depends on, emits permitted events, awaits results, and later continues.
 
-The exact ArvoEvent model, self-description semantics, validation rules, lineage fields, observability fields, and CloudEvent transformation semantics are defined in the dedicated ArvoEvent ADR.
+A handler must declare its complete contract capability set as part of its definition, before any execution instance begins. Every event type it may emit must be permitted by its own contract or a declared dependency, and an active execution cannot add undeclared capabilities. This static boundary makes a handler's possible event-driven effects explicit without making its behaviour deterministic — Arvo does not prescribe which permitted events it emits, in what order, how often, or on what reasoning.
 
-### ArvoContract
+Within an execution slice, Arvo does not constrain internal computation or use of implementation dependencies. Across a suspension boundary it does: no live implementation dependency may be relied upon to survive one. A handler's logical execution may span many deliveries and infrastructure executions, and must not require a continuously running process while awaiting events.
 
-An ArvoContract is a versioned capability and interface declaration for a node. It describes the events a node may accept and emit, providing the boundary through which independently implemented participants compose.
-
-An ArvoContract is not a participant registry, deployment descriptor, routing configuration, or concrete implementation. A node depends on contracts rather than knowledge of the participants implementing them. Discovery and routing are infrastructure responsibilities.
-
-An ArvoEventHandler must declare its complete ArvoContract capability set as part of its handler definition, before any execution instance begins. Every Arvo event type it may emit must be permitted by its implemented contract or one of its declared contract dependencies. An active execution instance cannot add undeclared Arvo event capabilities.
-
-This static capability boundary makes the handler's possible event-driven effects explicit and predictable without making its behaviour deterministic. Arvo does not prescribe which permitted events a handler emits, their sequence or frequency, or the reasoning that leads to them.
-
-Within an execution slice, Arvo does not constrain a handler's internal computation or its use of implementation dependencies. No live implementation dependency must be relied upon to survive a suspension boundary; resumable state semantics are defined separately. Implementation dependencies do not expand a handler's declared Arvo event capabilities.
-
-The exact contract model and compatibility rules are deferred to dedicated ADRs.
-
-### ArvoEventHandler
-
-An ArvoEventHandler is a resumable application-layer component that implements one ArvoContract and declares the ArvoContract dependencies with which it may interact. It can emit permitted events, await results when required, and later continue its work.
-
-An ArvoEventHandler's logical execution may span multiple event deliveries and infrastructure executions. It must not require one continuously running process while awaiting further events. The mechanism for representing, persisting, restoring, and migrating handler state is defined separately.
-
-The presence of a contract does not guarantee that a participating implementation is currently available. Infrastructure is responsible for routing. Non-delivery may occur, and its detection requires an explicit expectation, deadline, or adapter capability.
-
-The exact execution, state, suspension, resumption, concurrency, and recovery semantics are defined in dedicated ArvoEventHandler ADRs.
+The presence of a contract does not guarantee an available implementation. Non-delivery may occur, and detecting it requires an explicit expectation, deadline, or adapter capability.
 
 ## Invariants
 
-These are normative. Changing one is an architectural change and requires a superseding ADR.
+Normative. Changing one is an architectural change requiring a superseding ADR.
 
-### Infrastructure Independence
+**Infrastructure Independence.** The model must not depend on a particular broker, persistence implementation, hosting platform, scheduler, engine, or delivery mechanism. The meaning of events, contracts, validation outcomes, compatibility rules, and protocol transitions must not vary by adapter. Handler-declared implementation dependencies remain permitted and may impose their own deployment requirements. An adapter may impose additional constraints, but those constraints are not requirements of the model.
 
-The portable application model must not depend on a particular broker, persistence implementation, hosting platform, scheduler, workflow engine, or delivery mechanism selected by an infrastructure adapter. Handler-declared implementation dependencies remain permitted and may impose their own deployment requirements.
+**Event-Only Communication.** Inter-node interactions must be represented in the model as ArvoEvents governed by ArvoContracts. No node, coordinating or otherwise, may rely on a control mechanism absent from the model. Direct calls to implementation dependencies are permitted but sit outside the model and cannot serve as resumable inter-node interactions. Transports need not be event-native provided they preserve the corresponding Arvo event semantics.
 
-The handler interfaces and lifecycle semantics defined by the portable application model must remain portable across infrastructure adapters that support the required execution capability profile. Arvo does not guarantee portability of a handler's internal implementation logic; that depends on its runtime and declared implementation dependencies. The capability-profile model and adapter conformance requirements are defined separately.
+**Open Composition.** Arvo imposes no architectural limit on composition depth, topology, participant implementation, or infrastructure boundaries, and no participant is required to know the complete graph. Practical limits belong to the selected infrastructure.
 
-### Event-Only Communication
+**Explicit Contracts and Runtime Validation.** Nodes compose through explicit, versioned contracts, and the model requires runtime validation at defined trust boundaries. Compile-time types cannot establish validity across independently deployed, external, or cross-language participants, must not replace runtime validation, and must not preclude cross-language participation.
 
-Inter-node interactions must be represented within the portable application model as ArvoEvents governed by ArvoContracts. No node, including a coordinating node, may rely on a privileged communication or control mechanism that is absent from the portable application model.
+**Nondeterminism Is Permitted.** Arvo does not impose deterministic execution on application logic. Deterministic, imperative, nondeterministic, human-driven, and agentic handlers are all valid participants.
 
-Direct calls to databases, APIs, libraries, and other implementation dependencies are permitted, but they remain outside the portable application model and cannot be used as resumable inter-node interactions. If an external system participates as an Arvo node, its interactions with other nodes remain subject to the portable application model.
+**Observability by Default.** The model must preserve sufficient correlation, causation, lineage, and trace context to make distributed composition observable. Collection, retention, and export are infrastructure responsibilities; adapters may add telemetry provided it does not change the model.
 
-Physical transports and infrastructure execution mechanisms need not themselves be event-native if they preserve the corresponding Arvo event semantics.
-
-### Dynamic, Decentralized Composition
-
-Arvo imposes no architectural limit on composition depth, graph topology, participant implementation, or infrastructure boundaries. Practical resource and operational limits remain the responsibility of the selected infrastructure.
-
-The complete application graph does not need to be known or represented by any participant.
-
-### Infrastructure-Independent Protocol Semantics
-
-Arvo does not impose deterministic execution on application logic. However, the meaning of ArvoEvents, ArvoContracts, validation outcomes, compatibility rules, and protocol transitions within the portable application model must not change according to the selected infrastructure adapter.
-
-Deterministic, imperative, nondeterministic, human-driven, and agentic handlers are valid participants. An infrastructure adapter may impose additional constraints, but those constraints are not requirements of the portable application model.
-
-### Explicit Contracts and Runtime Validation
-
-Nodes compose through explicit, versioned contracts. The portable application model requires runtime validation at defined trust boundaries. Compile-time types improve developer experience but cannot establish validity across independently deployed, external, or cross-language participants.
-
-Dedicated ADRs define the validation boundaries and failure representations. Compile-time type safety does not replace runtime validation and must not prevent future cross-language participation.
-
-### Observability by Default
-
-The portable application model must preserve sufficient correlation, causation, lineage, and trace context to make distributed composition observable.
-
-Collection, retention, and export remain infrastructure responsibilities. The exact observability model is deferred to a dedicated ADR. Adapters may attach additional telemetry as long as it does not change the portable application model.
-
-### Explicit Failure Boundaries
-
-Arvo distinguishes among:
-
-- Event and protocol failures
-- Handler and application failures
-- Infrastructure and delivery failures
-
-Detailed failure representations and recovery semantics are deferred to dedicated ADRs.
-
-## Project Values
-
-These describe current project policy. They may evolve without superseding this ADR and are not requirements for Arvo conformance.
-
-### Standards-Based Interoperability
-
-Arvo uses established standards where they provide suitable semantics rather than defining new ones. Standards commitments that bind the model, such as the CloudEvent transformability required of every ArvoEvent, are recorded as part of AAM rather than as project policy.
-
-Arvo is TypeScript-first, with future support for other languages. The project avoids letting TypeScript implementation details become requirements of the portable application model; cross-language compatibility is addressed in a dedicated ADR.
-
-### Developer Experience
-
-Arvo prioritizes an approachable application-development experience. Strong opinions, validation, diagnostics, and type inference are used to reduce the effort required to build robust distributed and agentic systems, and compile-time type safety is provided as strongly as practical.
-
-Minimal dependencies are preferred, but not at the expense of correctness, standards compliance, observability, or developer experience.
-
-### Stable Evolution
-
-`arvo-core` v4 is a deliberate architectural rebuild and is not constrained by compatibility with earlier major versions.
-
-Compatibility guarantees for stable APIs, event representations, contracts, persisted state, and adapter interfaces will be defined separately before v4 is declared stable.
+**Explicit Failure Boundaries.** Arvo distinguishes event and protocol failures, handler and application failures, and infrastructure and delivery failures. Representations and recovery semantics are deferred.
 
 ## Delivery Assumptions
 
-Arvo applications must be designed for delivery environments in which the following may occur:
+Applications must be designed for environments producing duplicate, delayed, reordered, replayed, concurrent, or undelivered events. Arvo provides identifiers, metadata, protocol semantics, and extension points through which applications and adapters can detect and respond to these conditions where detection is possible; it prescribes no single handling policy and requires no single delivery guarantee from every adapter.
 
-- Duplicate events
-- Delayed events
-- Reordered events
-- Non-delivery
-- Concurrent delivery
-- Replayed events
+## What Arvo Is Not
 
-Arvo provides common identifiers, metadata, protocol semantics, and extension interfaces through which applications and adapters can detect and respond to these conditions where detection is possible. It does not prescribe one universal handling policy.
+Arvo is not a workflow or orchestration engine, a message broker or transport, a database or state store, a scheduler, a hosting platform, a service discovery system, a complete representation or controller of an application's graph, or a prescription of where node boundaries belong.
 
-Non-delivery can be detected only where an explicit expectation, deadline, or adapter capability makes detection possible. This ADR does not require one universal delivery guarantee from all infrastructure adapters. Adapter conformance levels, idempotency, replay, and delivery semantics are defined separately.
+It defines resumable handler lifecycle semantics; adapters implement durable execution, persistence, scheduling, and recovery. Defining those semantics does not make Arvo an execution engine.
 
-## Responsibility Boundaries
+It does not guarantee that a contract has an implementation, that an event will be delivered, or that adapters offer identical operational guarantees.
 
-Arvo is strongly opinionated about:
+It validates structure and protocol semantics, but successful validation establishes no identity, authenticity, authorization, confidentiality, tenant isolation, or trust. Those are supplied by applications and adapters; later ADRs may define interoperable security interfaces without making one security infrastructure part of the model.
 
-- Event and contract semantics
-- Runtime validation
-- Communication boundaries
-- Composition and lineage
-- Resumable application components
-- Observability
-- Error categorization
-- The portable application model
+## Project Values
 
-Arvo is deliberately unopinionated about:
+Non-normative. Current policy, revisable without superseding this ADR.
 
-- Message brokers and event delivery products
-- Databases and persistence technologies
-- Hosting and deployment platforms
-- Scheduling systems
-- Service discovery implementations
-- Execution and orchestration engines
-- Infrastructure topology
-
-Arvo defines interfaces and primitives through which integrations with current and future infrastructure can be built. It is not limited to any named platform or category of execution engine.
-
-## Security and Trust
-
-Arvo includes structural and protocol validation, but successful validation does not establish identity, authenticity, authorization, confidentiality, tenant isolation, or trust.
-
-Applications and infrastructure adapters are responsible for supplying these properties. Dedicated ADRs may define interoperable security interfaces without making one security infrastructure part of the portable application model.
-
-## Non-Goals
-
-Arvo is not:
-
-- A workflow or orchestration engine
-- A message broker or event transport
-- A database or state store
-- A scheduler
-- A hosting or deployment platform
-- A service discovery system
-- A complete representation or controller of an application's graph
-- A prescription of where node boundaries belong within an application
-
-Arvo does not guarantee that a contract implementation exists, that an event will be delivered, or that all infrastructure adapters provide identical operational guarantees.
-
-Arvo defines resumable handler lifecycle semantics, but infrastructure adapters implement durable execution, persistence, scheduling, and recovery. Defining those semantics does not make Arvo an execution engine.
+Arvo prefers established standards to invented ones; commitments that bind the model, such as CloudEvent transformability, are recorded as part of AAM rather than here. Arvo is TypeScript-first with future support for other languages, and avoids letting TypeScript details become model requirements. It prioritizes an approachable development experience — strong opinions, validation, diagnostics, and type inference as strong as practical. Minimal dependencies are preferred, though not at the expense of correctness, standards compliance, observability, or developer experience. `arvo-core` v4 is a deliberate rebuild unconstrained by earlier majors; compatibility guarantees for stable APIs, event representations, contracts, persisted state, and adapter interfaces will be defined before it is declared stable.
 
 ## Considered Alternatives
 
-### Conventional Orchestration Engine
+**A conventional orchestration engine** — rejected; owning execution, persistence, scheduling, and the whole graph duplicates established platforms and couples application behaviour to an Arvo runtime.
 
-Rejected because Arvo does not seek to own execution, persistence, scheduling, or the complete application graph. Doing so would duplicate established platforms and couple application behaviour to an Arvo runtime.
+**A workflow-engine abstraction layer** — rejected; reducing engines to one common API produces a lowest-common-denominator abstraction. Capability profiles are not that: they declare what a handler requires so an adapter can determine whether it can run it, without normalizing infrastructure APIs or guarantees.
 
-### Workflow-Engine Abstraction Layer
+**A pure event protocol** — rejected; an envelope alone provides no contracts, no resumable composition, no validation, and no coherent programming model.
 
-Rejected because reducing multiple engines to one common API would create a lowest-common-denominator engine abstraction. Arvo instead defines a portable application model and allows adapters to use infrastructure capabilities internally.
+**A broker-centric framework** — rejected; brokers are delivery infrastructure, and making broker concepts part of the model would undermine independence.
 
-Execution capability profiles do not normalize infrastructure APIs or guarantees. They declare handler requirements so that an adapter can determine whether it supports a handler without changing the portable application model.
-
-### Pure Event Protocol
-
-Rejected because an event envelope alone does not provide contracts, resumable component composition, validation, developer tooling, or a coherent application programming model.
-
-### Broker-Centric Framework
-
-Rejected because brokers are delivery infrastructure. Making broker concepts part of the portable application model would undermine infrastructure independence.
-
-### Independent Utility Library
-
-Rejected because disconnected event, validation, and telemetry utilities would not establish the architectural invariants required by the portable application model.
+**A collection of utilities** — rejected; disconnected event, validation, and telemetry helpers establish none of the invariants portable composition requires.
 
 ## Consequences
 
-### Benefits
+Gained:
 
-- Composition is closed, so a subgraph can be sealed behind one contract and domain or team boundaries can be drawn and redrawn without rearchitecting.
-- Node granularity is a reversible design decision rather than an architectural commitment; getting boundaries wrong early is cheap in both directions.
-- Reuse is of contract-addressed running capabilities rather than packages, enabling cross-team and cross-language reuse without bindings or a shared runtime.
-- The portable application model remains consistent across infrastructure adapters that support the required execution capability profile.
-- Declared contract boundaries make every handler's possible Arvo event effects explicit while allowing its internal behaviour to remain nondeterministic.
-- Deterministic and nondeterministic components can participate in one application model.
-- Human and external participation does not require a separate composition paradigm.
-- Contracts and runtime validation support independently deployed and cross-language participants.
-- Event-represented composition preserves infrastructure-independent behaviour within the portable application model.
-- New execution technologies can integrate without redefining the portable application model.
+- A subgraph can be sealed behind one contract, so domain and team boundaries can be drawn and redrawn without rearchitecting, and getting them wrong early is cheap in both directions.
+- Reuse is of contract-addressed running capabilities rather than packages, which makes cross-team and cross-language reuse possible without bindings or a shared runtime.
+- Deterministic components, nondeterministic agents, humans, and external systems participate in one composition model with no second paradigm and no seams between paradigms.
+- Declared boundaries make a handler's possible event effects explicit while leaving its internals free.
+- New execution technologies integrate without redefining the model.
 
-### Costs and Trade-offs
+Paid for:
 
-- Arvo applications may have fewer engine-specific conveniences than applications written directly against a particular platform.
-- The portable application model may not expose every proprietary guarantee or optimization.
-- Portability of handler implementation logic depends on its runtime and declared implementation dependencies.
-- Changing a handler's Arvo event capability set requires changing its handler definition and may require contract versioning and redeployment. Active executions cannot acquire new Arvo event capabilities dynamically.
-- Arvo does not prescribe where node boundaries belong. Granularity is an unguided design decision and can be wrong in either direction.
-- Declared event capabilities are boundary-local, so system-wide effect analysis requires traversing the graph rather than reading one contract.
-- Convergence across a boundary whose inner contracts have external consumers is a breaking change for those consumers.
-- Merging nodes unions their execution capability profiles and coarsens failure, retry, and lineage granularity.
-- Adapters carry significant responsibility for correctly mapping infrastructure behaviour to Arvo semantics.
-- Event-driven distributed applications must account for delivery uncertainty and partial failure.
-- Strong runtime validation and observability introduce implementation and execution overhead.
-- A decentralized graph can be more difficult to understand operationally, making high-quality lineage and telemetry essential.
+- Fewer engine-specific conveniences than writing directly against a platform, and no exposure of every proprietary guarantee or optimization.
+- Boundary placement is unguided; granularity can be wrong in either direction.
+- Effect visibility is boundary-local, so system-wide effect analysis means traversing the graph rather than reading one contract.
+- Convergence across a boundary whose inner contracts have external consumers breaks those consumers.
+- Merging nodes unions their capability profiles and coarsens failure, retry, and lineage granularity.
+- Contract-addressed reuse presumes discoverable participants, and discovery is an infrastructure concern Arvo does not provide.
+- Changing a handler's capability set means changing its definition, possibly versioning its contract, and redeploying.
+- Adapters carry heavy responsibility for mapping infrastructure behaviour to Arvo semantics correctly.
+- Runtime validation and observability cost throughput, and a decentralized graph is harder to reason about operationally, which makes lineage and telemetry quality essential rather than optional.
 
-These trade-offs are accepted. Arvo prioritizes the portable application model and composability over maximum exploitation of any single infrastructure platform.
+These are accepted. Arvo prioritizes portable, composable application semantics over maximum exploitation of any single platform.
 
 ## Deferred Decisions
 
-The following require dedicated ADRs or specifications:
+Each requires a dedicated ADR:
 
-- ArvoEvent structure, self-description, and CloudEvent transformation, including whether that transformation is lossless and bidirectional
+- ArvoEvent structure, self-description, and CloudEvent transformation, including whether it is lossless and bidirectional
 - ArvoContract structure, dependency declaration, event capabilities, resolution, and version compatibility
 - ArvoEventHandler execution semantics
 - Handler state serialization, persistence, migration, and recovery
@@ -310,27 +180,20 @@ The following require dedicated ADRs or specifications:
 
 ## Applying This ADR
 
-Every downstream ADR must state:
+Every downstream ADR must state what it adds to, refines, or excludes from the model; which invariants it depends on or strains; what it requires of infrastructure adapters; and what it leaves deferred.
 
-- what it adds to, refines, or excludes from the portable application model;
-- which invariants it depends on or strains;
-- what it requires of infrastructure adapters;
-- what it leaves deferred.
+The AAM membership lists are exhaustive as of this ADR. A downstream ADR placing a new concern inside or outside the model amends them by explicit reference. Concerns under Deferred Decisions have undetermined membership until decided — their absence from the lists is not exclusion.
 
-The membership lists in the **Arvo Application Model (AAM)** definition are exhaustive as of this ADR. A downstream ADR that places a new concern inside or outside the model amends those lists by explicit reference. Concerns listed under **Deferred Decisions** have undetermined membership until the relevant ADR decides it; their absence from the lists is not exclusion.
+Three constraints bind those decisions:
 
-### Standing Constraints
-
-Deferred decisions must preserve the following:
-
-- Durable records may carry node identity, but must not depend on it for continued correctness where a boundary refactor would invalidate that identity. Contract identity and execution identity must remain stable across composition and decomposition, so that lineage, persisted handler state, and external correlation survive a boundary change. Reversible composition depends on this.
-- Execution capability profiles must compose, because a sealed node's profile derives from the profiles of its members.
+- Durable records may carry node identity but must not depend on it for continued correctness where a boundary refactor would invalidate it. Contract identity and execution identity must survive composition and decomposition, so that lineage, persisted state, and external correlation survive a boundary change. Reversible composition depends on this.
+- Execution capability profiles must compose, because a sealed node's profile derives from its members'.
 - Contract compatibility rules determine how much internal change a sealed boundary can absorb, and therefore whether reversible composition holds in practice.
 
 ## Governance
 
-Accepted ADRs and feature specifications must conform to this decision. A later decision that conflicts with this ADR must identify the conflict explicitly and supersede the affected principle or this ADR as a whole.
+Accepted ADRs and specifications must conform to this decision. A later decision that conflicts with it must name the conflict explicitly and supersede the affected invariant, or this ADR as a whole.
 
-This repository is the canonical source of Arvo ecosystem ADRs until a dedicated architecture repository supersedes it. Ecosystem repositories must reference these records rather than maintain independent copies.
+This repository is the canonical source of Arvo ecosystem ADRs until a dedicated architecture repository supersedes it; other repositories reference these records rather than copying them.
 
-This ADR must be marked **Accepted** only after review confirms that it accurately describes the Arvo Application Model rather than the incidental details of any one implementation of it.
+This ADR must be marked **Accepted** only after review confirms it describes the Arvo Application Model rather than the incidental details of any one implementation.

--- a/docs/adr/000-arvo-system-identity-and-architectural-principles.md
+++ b/docs/adr/000-arvo-system-identity-and-architectural-principles.md
@@ -248,6 +248,9 @@ Rejected because disconnected event, validation, and telemetry utilities would n
 
 ### Benefits
 
+- Composition is closed, so a subgraph can be sealed behind one contract and domain or team boundaries can be drawn and redrawn without rearchitecting.
+- Node granularity is a reversible design decision rather than an architectural commitment; getting boundaries wrong early is cheap in both directions.
+- Reuse is of contract-addressed running capabilities rather than packages, enabling cross-team and cross-language reuse without bindings or a shared runtime.
 - The portable application model remains consistent across infrastructure adapters that support the required execution capability profile.
 - Declared contract boundaries make every handler's possible Arvo event effects explicit while allowing its internal behaviour to remain nondeterministic.
 - Deterministic and nondeterministic components can participate in one application model.
@@ -262,6 +265,10 @@ Rejected because disconnected event, validation, and telemetry utilities would n
 - The portable application model may not expose every proprietary guarantee or optimization.
 - Portability of handler implementation logic depends on its runtime and declared implementation dependencies.
 - Changing a handler's Arvo event capability set requires changing its handler definition and may require contract versioning and redeployment. Active executions cannot acquire new Arvo event capabilities dynamically.
+- Arvo does not prescribe where node boundaries belong. Granularity is an unguided design decision and can be wrong in either direction.
+- Declared event capabilities are boundary-local, so system-wide effect analysis requires traversing the graph rather than reading one contract.
+- Convergence across a boundary whose inner contracts have external consumers is a breaking change for those consumers.
+- Merging nodes unions their execution capability profiles and coarsens failure, retry, and lineage granularity.
 - Adapters carry significant responsibility for correctly mapping infrastructure behaviour to Arvo semantics.
 - Event-driven distributed applications must account for delivery uncertainty and partial failure.
 - Strong runtime validation and observability introduce implementation and execution overhead.

--- a/docs/adr/000-arvo-system-identity-and-architectural-principles.md
+++ b/docs/adr/000-arvo-system-identity-and-architectural-principles.md
@@ -323,7 +323,7 @@ The membership lists in the **Arvo Application Model (AAM)** definition are exha
 
 Deferred decisions must preserve the following:
 
-- Node identity must not become the durable key for anything a boundary refactor would invalidate, including lineage records, persisted handler state, and external correlation. Reversible composition depends on this.
+- Durable records may carry node identity, but must not depend on it for continued correctness where a boundary refactor would invalidate that identity. Contract identity and execution identity must remain stable across composition and decomposition, so that lineage, persisted handler state, and external correlation survive a boundary change. Reversible composition depends on this.
 - Execution capability profiles must compose, because a sealed node's profile derives from the profiles of its members.
 - Contract compatibility rules determine how much internal change a sealed boundary can absorb, and therefore whether reversible composition holds in practice.
 

--- a/docs/adr/000-arvo-system-identity-and-architectural-principles.md
+++ b/docs/adr/000-arvo-system-identity-and-architectural-principles.md
@@ -17,6 +17,8 @@ Those constraints are useful within their intended environments, but they make a
 
 Arvo needs an application model in which these different participants can compose without requiring one execution engine to own the complete process. Arvo seeks to keep their composition and lifecycle semantics portable while infrastructure adapters and platforms perform execution, persistence, delivery, scheduling, and recovery according to their strengths.
 
+The motivating thesis, its failure conditions, and a worked example are described in [the Arvo vision document](../vision.md). This ADR records the resulting architectural commitments.
+
 This ADR establishes the identity and architectural principles of Arvo. It governs the Arvo ecosystem beyond a single package or major version. Arvo v4 is the first implementation expected to conform to it.
 
 ## Decision

--- a/docs/adr/000-arvo-system-identity-and-architectural-principles.md
+++ b/docs/adr/000-arvo-system-identity-and-architectural-principles.md
@@ -1,0 +1,299 @@
+# ADR-000: Arvo System Identity and Architectural Principles
+
+- **Status:** Proposed
+- **Date:** 2026-07-31
+- **Scope:** Arvo ecosystem
+- **Decision owners:** Arvo maintainers
+
+## Conformance Language
+
+In this ADR, **must** denotes a requirement for Arvo conformance. **Should** denotes a recommendation that may be departed from with documented justification. **May** denotes a permitted choice.
+
+## Context
+
+Modern durable execution and workflow platforms provide valuable operational capabilities, but they commonly require application workflows to conform to platform-specific execution models. These models may impose determinism, functional purity, centralized workflow ownership, or other constraints necessary for a particular platform's operation.
+
+Those constraints are useful within their intended environments, but they make application behaviour dependent on the selected engine. They also become restrictive when an application combines conventional handlers, deterministic workflows, imperative processes, nondeterministic workflows, AI agents, human participation, and external systems.
+
+Arvo needs an application model in which these different participants can compose without requiring one execution engine to own the complete process. Arvo seeks to keep their composition and lifecycle semantics portable while infrastructure adapters and platforms perform execution, persistence, delivery, scheduling, and recovery according to their strengths.
+
+This ADR establishes the identity and architectural principles of Arvo. It governs the Arvo ecosystem beyond a single package or major version. Arvo v4 is the first implementation expected to conform to it.
+
+## Decision
+
+Arvo is a lightweight, opinionated framework that defines a portable application model for event-driven systems.
+
+Arvo does not execute that model itself and is not an orchestration engine or infrastructure runtime. It provides the protocol semantics, contracts, application primitives, and integration boundaries required to express event-driven application behaviour. Infrastructure adapters execute that behaviour and provide operational capabilities.
+
+An Arvo application is understood conceptually as a dynamic graph of independently participating nodes. Nodes compose exclusively through interactions represented by ArvoEvents and governed by declared ArvoContracts. The graph emerges from contracts, participating nodes, and emitted events; it does not require a complete central declaration or owner.
+
+## Terminology
+
+- **Node:** A conceptual participant in an Arvo application that exposes or consumes capabilities through Arvo contracts. A node may be implemented by an ArvoEventHandler, a human participant, or an external system.
+- **Inter-node interaction:** A request, signal, result, failure, or other exchange used to compose application behaviour between Arvo nodes.
+- **Implementation dependency:** A database, API, library, model provider, or other resource used internally by a node without participating in the portable application model.
+- **Handler:** An application-layer implementation of an Arvo node. An ArvoEventHandler implements one ArvoContract, declares its ArvoContract dependencies, and may continue its logical execution across multiple event deliveries and infrastructure executions.
+- **Infrastructure adapter:** An integration that binds Arvo's portable application model to execution, delivery, persistence, scheduling, discovery, or other infrastructure.
+- **Portable application model:** The ArvoEvent identities and data; ArvoContract identities, versions, and declared event capabilities; inter-node interactions; causation and lineage; handler interfaces and lifecycle semantics; execution capability requirements; validation and compatibility semantics; and failure categories whose meaning must remain consistent across supporting infrastructure adapters. It excludes physical transport, persistence technology, scheduling implementation, retry counts, batching, telemetry collection and export, and handler implementation dependencies.
+- **Execution slice:** One active period of handler execution, beginning when the handler receives or resumes from an event and ending when it completes, fails, or suspends while awaiting another event.
+- **Execution capability profile:** The declared runtime capabilities and constraints required to execute a handler. Its exact model is defined separately.
+
+## Architectural Thesis
+
+Application-layer choreography is Arvo's universal composition model.
+
+A node may represent a simple handler, a deterministic workflow, an imperative or nondeterministic process, an AI agent, a human participant, or an external system. External participants may act as conceptual nodes through a declared ArvoContract boundary, but Arvo does not model or control their internals.
+
+Orchestration is supported as **orchestrated choreography**. A coordinating node may direct or combine the work of other nodes, but it remains an ordinary participant. It communicates through ArvoEvents governed by declared ArvoContracts and receives no privileged, out-of-band control path.
+
+Every inter-node interaction must be represented within the portable application model as an ArvoEvent. Physical transports and internal execution mechanisms may differ. Infrastructure adapters may use platform-native capabilities internally, including optimizations, provided they do not bypass or change the portable application model.
+
+### Composition Closure
+
+Composition is closed: any set of composed nodes can itself be presented as a single node behind one ArvoContract. Composition and decomposition are both first-class and reversible. Several nodes may converge into one, and one node may bifurcate into several, as domain understanding, ownership, scaling, or reuse requires. Arvo makes every boundary legal and prescribes none; where to place a node boundary is an application design decision.
+
+Closure is what allows choreography semantics to hold at any scale. The same composition model applies to a single handler, a coordinating node, and a sealed subgraph of arbitrary depth, so a growing system does not require a second paradigm at subsystem boundaries.
+
+Two limits follow. A handler's declared event capabilities are boundary-local: they describe one hop, not the transitive effects of everything behind a sealed node. And reversibility is bounded. Decomposition behind a sealed boundary is transparent to callers, while convergence is transparent only where no external participant addressed the inner contracts.
+
+## Core Concepts
+
+Arvo is founded on three primary concepts.
+
+### ArvoEvent
+
+An ArvoEvent is a JSON-serializable event used for communication between Arvo nodes. It can be transformed into a CloudEvent for standards-based interoperability.
+
+The exact ArvoEvent model, self-description semantics, validation rules, lineage fields, observability fields, and CloudEvent transformation semantics are defined in the dedicated ArvoEvent ADR.
+
+### ArvoContract
+
+An ArvoContract is a versioned capability and interface declaration for a node. It describes the events a node may accept and emit, providing the boundary through which independently implemented participants compose.
+
+An ArvoContract is not a participant registry, deployment descriptor, routing configuration, or concrete implementation. A node depends on contracts rather than knowledge of the participants implementing them. Discovery and routing are infrastructure responsibilities.
+
+An ArvoEventHandler must declare its complete ArvoContract capability set as part of its handler definition, before any execution instance begins. Every Arvo event type it may emit must be permitted by its implemented contract or one of its declared contract dependencies. An active execution instance cannot add undeclared Arvo event capabilities.
+
+This static capability boundary makes the handler's possible event-driven effects explicit and predictable without making its behaviour deterministic. Arvo does not prescribe which permitted events a handler emits, their sequence or frequency, or the reasoning that leads to them.
+
+Within an execution slice, Arvo does not constrain a handler's internal computation or its use of implementation dependencies. No live implementation dependency is assumed to survive a suspension boundary; resumable state semantics are defined separately. Implementation dependencies do not expand a handler's declared Arvo event capabilities.
+
+The exact contract model and compatibility rules are deferred to dedicated ADRs.
+
+### ArvoEventHandler
+
+An ArvoEventHandler is a resumable application-layer component that implements one ArvoContract and declares the ArvoContract dependencies with which it may interact. It can emit permitted events, await results when required, and later continue its work.
+
+An ArvoEventHandler's logical execution may span multiple event deliveries and infrastructure executions. It must not require one continuously running process while awaiting further events. The mechanism for representing, persisting, restoring, and migrating handler state is defined separately.
+
+The presence of a contract does not guarantee that a participating implementation is currently available. Infrastructure is responsible for routing. Non-delivery may occur, and its detection requires an explicit expectation, deadline, or adapter capability.
+
+The exact execution, state, suspension, resumption, concurrency, and recovery semantics are defined in dedicated ArvoEventHandler ADRs.
+
+## Architectural Principles
+
+### Infrastructure Independence
+
+The portable application model must not depend on a particular broker, persistence implementation, hosting platform, scheduler, workflow engine, or delivery mechanism selected by an infrastructure adapter. Handler-declared implementation dependencies remain permitted and may impose their own deployment requirements.
+
+The handler interfaces and lifecycle semantics defined by the portable application model must remain portable across infrastructure adapters that support the required execution capability profile. Arvo does not guarantee portability of a handler's internal implementation logic; that depends on its runtime and declared implementation dependencies. The capability-profile model and adapter conformance requirements are defined separately.
+
+### Event-Only Communication
+
+Inter-node interactions must be represented within the portable application model as ArvoEvents governed by ArvoContracts. No node, including a coordinating node, may rely on a privileged communication or control mechanism that is absent from the portable application model.
+
+Direct calls to databases, APIs, libraries, and other implementation dependencies are permitted, but they remain outside the portable application model and cannot be used as resumable inter-node interactions. If an external system participates as an Arvo node, its interactions with other nodes remain subject to the portable application model.
+
+Physical transports and infrastructure execution mechanisms need not themselves be event-native if they preserve the corresponding Arvo event semantics.
+
+### Dynamic, Decentralized Composition
+
+Arvo imposes no architectural limit on composition depth, graph topology, participant implementation, or infrastructure boundaries. Practical resource and operational limits remain the responsibility of the selected infrastructure.
+
+The complete application graph does not need to be known or represented by any participant.
+
+### Infrastructure-Independent Protocol Semantics
+
+Arvo does not impose deterministic execution on application logic. However, the meaning of ArvoEvents, ArvoContracts, validation outcomes, compatibility rules, and protocol transitions within the portable application model must not change according to the selected infrastructure adapter.
+
+Deterministic, imperative, nondeterministic, human-driven, and agentic handlers are valid participants. An infrastructure adapter may impose additional constraints, but those constraints are not requirements of the portable application model.
+
+### Explicit Contracts and Runtime Validation
+
+Nodes compose through explicit, versioned contracts. The portable application model requires runtime validation at defined trust boundaries. Compile-time types improve developer experience but cannot establish validity across independently deployed, external, or cross-language participants.
+
+Dedicated ADRs define the validation boundaries and failure representations. Compile-time type safety should be provided as strongly as practical, but it does not replace runtime validation and must not prevent future cross-language participation.
+
+### Standards-Based Interoperability
+
+Arvo uses established standards where they provide suitable semantics. ArvoEvent supports transformation into a CloudEvent for interoperability while remaining an independent JSON-serializable event model.
+
+Arvo is TypeScript-first, with future support for other languages. TypeScript implementation details must not unnecessarily become protocol requirements.
+
+### Observability by Default
+
+The portable application model must preserve sufficient correlation, causation, lineage, and trace context to make distributed composition observable.
+
+Collection, retention, and export remain infrastructure responsibilities. The exact observability model is deferred to a dedicated ADR. Adapters may attach additional telemetry as long as it does not change the portable application model.
+
+### Explicit Failure Boundaries
+
+Arvo distinguishes among:
+
+- Event and protocol failures
+- Handler and application failures
+- Infrastructure and delivery failures
+
+Detailed failure representations and recovery semantics are deferred to dedicated ADRs.
+
+### Developer Experience
+
+Arvo prioritizes an approachable application-development experience. Strong opinions, validation, diagnostics, and type inference should reduce the effort required to build robust distributed and agentic systems.
+
+Minimal dependencies are preferred, but not at the expense of correctness, standards compliance, observability, or developer experience.
+
+### Stable Evolution
+
+Arvo v4 is a deliberate architectural rebuild and is not constrained by compatibility with earlier major versions.
+
+Compatibility guarantees for stable APIs, event representations, contracts, persisted state, and adapter interfaces must be defined separately before v4 is declared stable.
+
+## Delivery Assumptions
+
+Arvo applications must be designed for delivery environments in which the following may occur:
+
+- Duplicate events
+- Delayed events
+- Reordered events
+- Non-delivery
+- Concurrent delivery
+- Replayed events
+
+Arvo provides common identifiers, metadata, protocol semantics, and extension interfaces through which applications and adapters can detect and respond to these conditions where detection is possible. It does not prescribe one universal handling policy.
+
+Non-delivery can be detected only where an explicit expectation, deadline, or adapter capability makes detection possible. This ADR does not require one universal delivery guarantee from all infrastructure adapters. Adapter conformance levels, idempotency, replay, and delivery semantics are defined separately.
+
+## Responsibility Boundaries
+
+Arvo is strongly opinionated about:
+
+- Event and contract semantics
+- Runtime validation
+- Communication boundaries
+- Composition and lineage
+- Resumable application components
+- Observability
+- Error categorization
+- The portable application model
+
+Arvo is deliberately unopinionated about:
+
+- Message brokers and event delivery products
+- Databases and persistence technologies
+- Hosting and deployment platforms
+- Scheduling systems
+- Service discovery implementations
+- Execution and orchestration engines
+- Infrastructure topology
+
+Arvo defines interfaces and primitives through which integrations with current and future infrastructure can be built. It is not limited to any named platform or category of execution engine.
+
+## Security and Trust
+
+Arvo includes structural and protocol validation, but successful validation does not establish identity, authenticity, authorization, confidentiality, tenant isolation, or trust.
+
+Applications and infrastructure adapters are responsible for supplying these properties. Dedicated ADRs may define interoperable security interfaces without making one security infrastructure part of the portable application model.
+
+## Non-Goals
+
+Arvo is not:
+
+- A workflow or orchestration engine
+- A message broker or event transport
+- A database or state store
+- A scheduler
+- A hosting or deployment platform
+- A service discovery system
+- A complete representation or controller of an application's graph
+
+Arvo does not guarantee that a contract implementation exists, that an event will be delivered, or that all infrastructure adapters provide identical operational guarantees.
+
+Arvo defines resumable handler lifecycle semantics, but infrastructure adapters implement durable execution, persistence, scheduling, and recovery. Defining those semantics does not make Arvo an execution engine.
+
+## Considered Alternatives
+
+### Conventional Orchestration Engine
+
+Rejected because Arvo does not seek to own execution, persistence, scheduling, or the complete application graph. Doing so would duplicate established platforms and couple application behaviour to an Arvo runtime.
+
+### Workflow-Engine Abstraction Layer
+
+Rejected because reducing multiple engines to one common API would create a lowest-common-denominator engine abstraction. Arvo instead defines a portable application model and allows adapters to use infrastructure capabilities internally.
+
+Execution capability profiles do not normalize infrastructure APIs or guarantees. They declare handler requirements so that an adapter can determine whether it supports a handler without changing the portable application model.
+
+### Pure Event Protocol
+
+Rejected because an event envelope alone does not provide contracts, resumable component composition, validation, developer tooling, or a coherent application programming model.
+
+### Broker-Centric Framework
+
+Rejected because brokers are delivery infrastructure. Making broker concepts part of the portable application model would undermine infrastructure independence.
+
+### Independent Utility Library
+
+Rejected because disconnected event, validation, and telemetry utilities would not establish the architectural invariants required by the portable application model.
+
+## Consequences
+
+### Benefits
+
+- The portable application model remains consistent across infrastructure adapters that support the required execution capability profile.
+- Declared contract boundaries make every handler's possible Arvo event effects explicit while allowing its internal behaviour to remain nondeterministic.
+- Deterministic and nondeterministic components can participate in one application model.
+- Human and external participation does not require a separate composition paradigm.
+- Contracts and runtime validation support independently deployed and cross-language participants.
+- Event-represented composition preserves infrastructure-independent behaviour within the portable application model.
+- New execution technologies can integrate without redefining the portable application model.
+
+### Costs and Trade-offs
+
+- Arvo applications may have fewer engine-specific conveniences than applications written directly against a particular platform.
+- The portable application model may not expose every proprietary guarantee or optimization.
+- Portability of handler implementation logic depends on its runtime and declared implementation dependencies.
+- Changing a handler's Arvo event capability set requires changing its handler definition and may require contract versioning and redeployment. Active executions cannot acquire new Arvo event capabilities dynamically.
+- Adapters carry significant responsibility for correctly mapping infrastructure behaviour to Arvo semantics.
+- Event-driven distributed applications must account for delivery uncertainty and partial failure.
+- Strong runtime validation and observability introduce implementation and execution overhead.
+- A decentralized graph can be more difficult to understand operationally, making high-quality lineage and telemetry essential.
+
+These trade-offs are accepted. Arvo prioritizes the portable application model and composability over maximum exploitation of any single infrastructure platform.
+
+## Deferred Decisions
+
+The following require dedicated ADRs or specifications:
+
+- ArvoEvent structure, self-description, and CloudEvent transformation
+- ArvoContract structure, dependency declaration, event capabilities, resolution, and version compatibility
+- ArvoEventHandler execution semantics
+- Handler state serialization, persistence, migration, and recovery
+- Handler concurrency and event-waiting patterns
+- Cancellation, interruption, and compensation semantics
+- Timers, deadlines, scheduling, and time semantics
+- Delivery ordering scope and concurrent event handling
+- Handler execution capability profiles
+- Formal definition and boundaries of an Arvo application
+- Observability fields and propagation
+- Event, application, and infrastructure failure models
+- Delivery guarantees, replay, deduplication, and idempotency
+- Infrastructure adapter interfaces and conformance
+- Security and trust integration
+- Cross-language protocol compatibility
+
+## Governance
+
+Accepted ADRs and feature specifications must conform to this decision. A later decision that conflicts with this ADR must identify the conflict explicitly and supersede the affected principle or this ADR as a whole.
+
+This repository is the canonical source of Arvo ecosystem ADRs until a dedicated architecture repository supersedes it. Ecosystem repositories must reference these records rather than maintain independent copies.
+
+This ADR should be marked **Accepted** only after review confirms that it accurately represents Arvo's enduring identity rather than the incidental details of its current TypeScript implementation.

--- a/docs/adr/000-arvo-system-identity-and-architectural-principles.md
+++ b/docs/adr/000-arvo-system-identity-and-architectural-principles.md
@@ -163,9 +163,9 @@ Minimal dependencies are preferred, but not at the expense of correctness, stand
 
 ### Stable Evolution
 
-Arvo v4 is a deliberate architectural rebuild and is not constrained by compatibility with earlier major versions.
+`arvo-core` v4 is a deliberate architectural rebuild and is not constrained by compatibility with earlier major versions.
 
-Compatibility guarantees for stable APIs, event representations, contracts, persisted state, and adapter interfaces must be defined separately before v4 is declared stable.
+Compatibility guarantees for stable APIs, event representations, contracts, persisted state, and adapter interfaces will be defined separately before v4 is declared stable.
 
 ## Delivery Assumptions
 
@@ -224,6 +224,7 @@ Arvo is not:
 - A hosting or deployment platform
 - A service discovery system
 - A complete representation or controller of an application's graph
+- A prescription of where node boundaries belong within an application
 
 Arvo does not guarantee that a contract implementation exists, that an event will be delivered, or that all infrastructure adapters provide identical operational guarantees.
 
@@ -331,4 +332,4 @@ Accepted ADRs and feature specifications must conform to this decision. A later 
 
 This repository is the canonical source of Arvo ecosystem ADRs until a dedicated architecture repository supersedes it. Ecosystem repositories must reference these records rather than maintain independent copies.
 
-This ADR should be marked **Accepted** only after review confirms that it accurately describes the Arvo Application Model rather than the incidental details of any one implementation of it.
+This ADR must be marked **Accepted** only after review confirms that it accurately describes the Arvo Application Model rather than the incidental details of any one implementation of it.

--- a/docs/adr/000-arvo-system-identity-and-architectural-principles.md
+++ b/docs/adr/000-arvo-system-identity-and-architectural-principles.md
@@ -36,7 +36,7 @@ An Arvo application is understood conceptually as a dynamic graph of independent
 - **Implementation dependency:** A database, API, library, model provider, or other resource used internally by a node without participating in the portable application model.
 - **Handler:** An application-layer implementation of an Arvo node. An ArvoEventHandler implements one ArvoContract, declares its ArvoContract dependencies, and may continue its logical execution across multiple event deliveries and infrastructure executions.
 - **Infrastructure adapter:** An integration that binds Arvo's portable application model to execution, delivery, persistence, scheduling, discovery, or other infrastructure.
-- **Arvo Application Model (AAM):** Arvo's versioned, language-independent portable application model, defined by this ADR and its descendants. It comprises the ArvoEvent identities and data; ArvoContract identities, versions, and declared event capabilities; inter-node interactions; causation, lineage, and trace context; handler interfaces and lifecycle semantics; execution capability requirements; validation and compatibility semantics; and failure categories whose meaning must remain consistent across supporting infrastructure adapters. It excludes physical transport, persistence technology, scheduling implementation, retry counts, batching, telemetry collection and export, and handler implementation dependencies. AAM versions are distinct from the versions of any package implementing them; `arvo-core` v4 is the first TypeScript implementation of AAM 1.
+- **Arvo Application Model (AAM):** Arvo's versioned, language-independent portable application model, defined by this ADR and its descendants. It comprises the ArvoEvent identities, data, and CloudEvent transformability; ArvoContract identities, versions, and declared event capabilities; inter-node interactions; causation, lineage, and trace context; handler interfaces and lifecycle semantics; execution capability requirements; validation and compatibility semantics; and failure categories whose meaning must remain consistent across supporting infrastructure adapters. It excludes physical transport, persistence technology, scheduling implementation, retry counts, batching, telemetry collection and export, and handler implementation dependencies. AAM versions are distinct from the versions of any package implementing them; `arvo-core` v4 is the first TypeScript implementation of AAM 1.
 
   *AAM* is the formal name. *Portable application model* is used descriptively throughout this ADR and refers to the same thing.
 - **Execution slice:** One active period of handler execution, beginning when the handler receives or resumes from an event and ending when it completes, fails, or suspends while awaiting another event.
@@ -66,7 +66,7 @@ Arvo is founded on three primary concepts.
 
 ### ArvoEvent
 
-An ArvoEvent is a JSON-serializable event used for communication between Arvo nodes. It can be transformed into a CloudEvent for standards-based interoperability. Whether that transformation is lossless and bidirectional is not decided here and is determined by the ArvoEvent ADR.
+An ArvoEvent is a JSON-serializable event used for communication between Arvo nodes. Every ArvoEvent must be transformable into a CloudEvent for standards-based interoperability. Transformability is a binding capability of AAM 1; whether the transformation is lossless and bidirectional is determined by the ArvoEvent ADR.
 
 The exact ArvoEvent model, self-description semantics, validation rules, lineage fields, observability fields, and CloudEvent transformation semantics are defined in the dedicated ArvoEvent ADR.
 
@@ -152,7 +152,7 @@ These describe current project policy. They may evolve without superseding this 
 
 ### Standards-Based Interoperability
 
-Arvo uses established standards where they provide suitable semantics rather than defining new ones. The CloudEvent transformation described under ArvoEvent is one instance.
+Arvo uses established standards where they provide suitable semantics rather than defining new ones. Standards commitments that bind the model, such as the CloudEvent transformability required of every ArvoEvent, are recorded as part of AAM rather than as project policy.
 
 Arvo is TypeScript-first, with future support for other languages. The project avoids letting TypeScript implementation details become requirements of the portable application model; cross-language compatibility is addressed in a dedicated ADR.
 

--- a/docs/adr/000-arvo-system-identity-and-architectural-principles.md
+++ b/docs/adr/000-arvo-system-identity-and-architectural-principles.md
@@ -37,7 +37,7 @@ An Arvo application is understood conceptually as a dynamic graph of independent
 - **Handler:** An application-layer implementation of an Arvo node. An ArvoEventHandler implements one ArvoContract, declares its ArvoContract dependencies, and may continue its logical execution across multiple event deliveries and infrastructure executions.
 - **Infrastructure adapter:** An integration that binds Arvo's portable application model to execution, delivery, persistence, scheduling, discovery, or other infrastructure.
 - **Arvo Application Model (AAM):** The versioned, language-independent model defined by this ADR and its descendants. AAM versions are distinct from the versions of any package implementing them. `arvo-core` v4 is the first TypeScript implementation of AAM 1.
-- **Portable application model:** The ArvoEvent identities and data; ArvoContract identities, versions, and declared event capabilities; inter-node interactions; causation and lineage; handler interfaces and lifecycle semantics; execution capability requirements; validation and compatibility semantics; and failure categories whose meaning must remain consistent across supporting infrastructure adapters. It excludes physical transport, persistence technology, scheduling implementation, retry counts, batching, telemetry collection and export, and handler implementation dependencies.
+- **Portable application model:** The ArvoEvent identities and data; ArvoContract identities, versions, and declared event capabilities; inter-node interactions; causation, lineage, and trace context; handler interfaces and lifecycle semantics; execution capability requirements; validation and compatibility semantics; and failure categories whose meaning must remain consistent across supporting infrastructure adapters. It excludes physical transport, persistence technology, scheduling implementation, retry counts, batching, telemetry collection and export, and handler implementation dependencies.
 - **Execution slice:** One active period of handler execution, beginning when the handler receives or resumes from an event and ending when it completes, fails, or suspends while awaiting another event.
 - **Execution capability profile:** The declared runtime capabilities and constraints required to execute a handler. Its exact model is defined separately.
 
@@ -65,7 +65,7 @@ Arvo is founded on three primary concepts.
 
 ### ArvoEvent
 
-An ArvoEvent is a JSON-serializable event used for communication between Arvo nodes. It can be transformed into a CloudEvent for standards-based interoperability.
+An ArvoEvent is a JSON-serializable event used for communication between Arvo nodes. It can be transformed into a CloudEvent for standards-based interoperability. Whether that transformation is lossless and bidirectional is not decided here and is determined by the ArvoEvent ADR.
 
 The exact ArvoEvent model, self-description semantics, validation rules, lineage fields, observability fields, and CloudEvent transformation semantics are defined in the dedicated ArvoEvent ADR.
 
@@ -79,7 +79,7 @@ An ArvoEventHandler must declare its complete ArvoContract capability set as par
 
 This static capability boundary makes the handler's possible event-driven effects explicit and predictable without making its behaviour deterministic. Arvo does not prescribe which permitted events a handler emits, their sequence or frequency, or the reasoning that leads to them.
 
-Within an execution slice, Arvo does not constrain a handler's internal computation or its use of implementation dependencies. No live implementation dependency is assumed to survive a suspension boundary; resumable state semantics are defined separately. Implementation dependencies do not expand a handler's declared Arvo event capabilities.
+Within an execution slice, Arvo does not constrain a handler's internal computation or its use of implementation dependencies. No live implementation dependency must be relied upon to survive a suspension boundary; resumable state semantics are defined separately. Implementation dependencies do not expand a handler's declared Arvo event capabilities.
 
 The exact contract model and compatibility rules are deferred to dedicated ADRs.
 
@@ -127,7 +127,7 @@ Deterministic, imperative, nondeterministic, human-driven, and agentic handlers 
 
 Nodes compose through explicit, versioned contracts. The portable application model requires runtime validation at defined trust boundaries. Compile-time types improve developer experience but cannot establish validity across independently deployed, external, or cross-language participants.
 
-Dedicated ADRs define the validation boundaries and failure representations. Compile-time type safety should be provided as strongly as practical, but it does not replace runtime validation and must not prevent future cross-language participation.
+Dedicated ADRs define the validation boundaries and failure representations. Compile-time type safety does not replace runtime validation and must not prevent future cross-language participation.
 
 ### Observability by Default
 
@@ -157,7 +157,7 @@ Arvo is TypeScript-first, with future support for other languages. The project a
 
 ### Developer Experience
 
-Arvo prioritizes an approachable application-development experience. Strong opinions, validation, diagnostics, and type inference should reduce the effort required to build robust distributed and agentic systems.
+Arvo prioritizes an approachable application-development experience. Strong opinions, validation, diagnostics, and type inference are used to reduce the effort required to build robust distributed and agentic systems, and compile-time type safety is provided as strongly as practical.
 
 Minimal dependencies are preferred, but not at the expense of correctness, standards compliance, observability, or developer experience.
 
@@ -289,7 +289,7 @@ These trade-offs are accepted. Arvo prioritizes the portable application model a
 
 The following require dedicated ADRs or specifications:
 
-- ArvoEvent structure, self-description, and CloudEvent transformation
+- ArvoEvent structure, self-description, and CloudEvent transformation, including whether that transformation is lossless and bidirectional
 - ArvoContract structure, dependency declaration, event capabilities, resolution, and version compatibility
 - ArvoEventHandler execution semantics
 - Handler state serialization, persistence, migration, and recovery

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,20 @@
+# Architecture Decision Records
+
+This directory contains the Architecture Decision Records (ADRs) for Arvo.
+
+ADRs record durable architectural decisions, their context, and their consequences. Feature specifications may provide detailed requirements and acceptance criteria, but they must remain consistent with accepted ADRs or explicitly propose a superseding decision.
+
+This repository is the canonical source of Arvo ecosystem ADRs until a dedicated architecture repository supersedes it. Other ecosystem repositories must reference these records rather than maintain independent copies.
+
+## Status
+
+- **Proposed**: Under review and not yet binding.
+- **Accepted**: Governs the architecture until superseded.
+- **Superseded**: Replaced by a later ADR.
+- **Rejected**: Considered but not adopted.
+
+## Records
+
+| ADR | Title | Status |
+| --- | --- | --- |
+| [ADR-000](./000-arvo-system-identity-and-architectural-principles.md) | Arvo System Identity and Architectural Principles | Proposed |

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -17,4 +17,4 @@ This repository is the canonical source of Arvo ecosystem ADRs until a dedicated
 
 | ADR | Title | Status |
 | --- | --- | --- |
-| [ADR-000](./000-arvo-system-identity-and-architectural-principles.md) | Arvo System Identity and Architectural Principles | Proposed |
+| [ADR-000](./000-arvo-system-identity-and-architectural-principles.md) | Arvo System Identity and Architectural Invariants | Proposed |

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -17,4 +17,4 @@ This repository is the canonical source of Arvo ecosystem ADRs until a dedicated
 
 | ADR | Title | Status |
 | --- | --- | --- |
-| [ADR-000](./000-arvo-system-identity-and-architectural-principles.md) | Arvo System Identity and Architectural Invariants | Proposed |
+| [ADR-000](./000-arvo-system-identity-and-architectural-principles.md) | Arvo System Identity and Architectural Invariants | Accepted |

--- a/docs/vision.md
+++ b/docs/vision.md
@@ -1,52 +1,55 @@
 # Arvo — Vision
 
-> Non-normative. This document explains why Arvo exists and what it is betting on.
-> The binding architectural commitments are recorded in
-> [ADR-000](adr/000-arvo-system-identity-and-architectural-principles.md).
+> Non-normative. This explains why Arvo exists and what it is betting on.
+> The binding commitments are in [ADR-000](adr/000-arvo-system-identity-and-architectural-principles.md).
+
+## A process nobody can model cleanly
+
+A purchase order needs pricing, drafted contract terms, a human sign-off, and settlement against an ERP.
+
+Pricing is deterministic code. The terms come from a model that produces something different every time it runs. The sign-off arrives three days later, after two deploys. The ERP predates everyone in the room and will not be changing.
+
+Four participants. Four incompatible execution characteristics — deterministic, nondeterministic, human-latency, foreign. Nothing available treats them as the same kind of thing.
+
+A durable execution platform models the pricing beautifully and treats the agent and the human as escapes from its model. An agent framework inverts that. Plain choreography treats all four equally and then leaves you with a process that exists nowhere, that nobody can see once it passes a few dozen participants. So the process gets built across three tools with a task table bolted on for the humans, and the seams between them are where it breaks at 2am.
+
+Two further things go wrong over time. Boundaries harden: where the service boundary landed in month one is where it stays, because it is also the deployment boundary and the codebase boundary — and domain understanding arrives in month nine. And whichever engine gets adopted to solve the first problem, the composition semantics of the whole application quietly become that engine's semantics.
 
 ## What Arvo is
 
-Arvo is a portable application model for event-driven systems. It defines how independently built participants — conventional handlers, deterministic workflows, AI agents, human approvals, external systems — compose through versioned contracts and events.
+Arvo is a portable application model for event-driven systems. It defines how independently built participants — handlers, deterministic workflows, agents, humans, external systems — compose through versioned contracts and events.
 
 Arvo does not execute that model. Infrastructure adapters do.
 
 ## The bet
 
-**One composition model, at any scale.** Application logic is becoming a mixture. A single business process now spans deterministic code, a nondeterministic agent, a human who takes three days to respond, and a system you do not control. No execution engine is going to own that mixture. Arvo bets that the layer worth standardising is therefore composition, not execution — and that choreography, with orchestration expressed as an ordinary participant inside it rather than as a privileged conductor, is the model that spans all of it.
+**One model, no second-class participants.** Choreography is the substrate, always. Orchestration is a pattern inside it rather than an alternative to it: a coordinating node may direct the others, but it is an ordinary participant speaking events under contracts, with no privileged control path. The pricing workflow, the agent, the human queue, and the ERP boundary are all nodes. None of them is an exception, so there are no seams between paradigms — because there is only one.
 
-**Boundaries you can move.** Composition is closed: any group of nodes can be sealed behind a single contract and presented as one node. That works in both directions. Several nodes converge into one when you want less surface; one node bifurcates into several when a seam turns out to be real. Node granularity becomes a reversible design decision rather than an architectural commitment, so being wrong about service boundaries early is cheap — in a way it is not when the service boundary is also the deployment boundary and the codebase boundary.
+**Boundaries you can move.** Composition is closed: any group of nodes can be sealed behind a single contract and presented as one node. It works in both directions. Several nodes converge into one when you want less surface; one node bifurcates into several when a seam turns out to be real. Nothing new is required to do it — a sealed subgraph is just a handler implementing the outer contract.
 
-The unit of reuse follows from this. You do not import a capability, you address its contract. What is behind it may be TypeScript, may be Python, may be a queue a human works from. Consumers cannot tell and do not need to.
+Say pricing and terms-drafting turn out to belong together, and drafting is absorbed into pricing. Order intake always addressed the pricing contract, which is unchanged, so nothing calling in notices. The drafting contract, which only pricing ever addressed, disappears from the graph. That is the rule and not a lucky case: splitting behind a boundary is always invisible, and merging is invisible exactly when the absorbed contracts had no outside callers.
 
-**It outlives the engine you picked.** Application semantics stay portable across infrastructure adapters. The first two legs are what you use Arvo for; this is what keeps them from expiring when the platform underneath changes.
+The reuse model follows. You do not import a capability, you address its contract. What is behind it may be TypeScript today and something else later — a Python service, a queue a human works from. Consumers cannot tell, and getting service boundaries wrong early stops being expensive.
+
+**It outlives the engine.** Composition and handler lifecycle semantics stay portable across infrastructure adapters. The first two claims are what you use Arvo for; this is what stops them expiring when the platform underneath changes.
 
 ## How this could be wrong
 
-Worth stating plainly, so it can be judged later.
+Stated plainly, so it can be judged later.
 
 **Portability could turn out to be free.** If durable execution engines converge on a shared open programming model, the independence Arvo buys stops being worth paying for.
 
-**Choreography's cost might not be paid off.** The standing objection is that in a choreographed system the process exists nowhere and nobody can see it. Arvo's answer is that declared contracts make the possible edges statically visible and lineage makes the actual edges visible after the fact. If that answer does not hold at fifty nodes in practice, teams will retreat to central orchestrators and the universal composition claim fails.
+**Choreography's cost might not be paid off.** The standing objection is real: in a choreographed system the process exists nowhere. Arvo's answer is that declared contracts make the possible edges statically visible and lineage makes the actual edges visible afterwards. If that does not hold at fifty nodes in practice, teams retreat to central orchestrators and the universal composition claim fails with them.
 
-**Orchestrated choreography could prove too expensive.** A coordinating node with no privileged control path also has no cheap cancellation, no cheap timeout, and no cheap way to abort everything downstream. All of it must be modelled as events. If that is ergonomically painful enough, people will want the back channel — and the model forbids it.
+**Orchestrated choreography could prove too expensive.** A coordinator with no privileged control path also has no cheap cancellation, no cheap timeout, and no cheap way to abort everything downstream. All of it has to be modelled as events. If that is painful enough, people will want the back channel — and the model forbids it.
 
-**Uniformity could be lowest-common-denominator in disguise.** Arvo rejects workflow-engine abstraction layers for flattening engines to a common case. The same charge can be aimed at one composition model serving deterministic workflows, agents, and humans alike. The answer is that Arvo composes rather than normalizes, and that capability profiles carry the differences — but that answer has to survive contact with real systems.
+**Uniformity could be lowest-common-denominator in disguise.** Arvo rejects workflow-engine abstraction layers for flattening engines to a common case. The same charge can be aimed at one composition model serving deterministic workflows, agents, and humans alike. The answer is that Arvo composes rather than normalizes, and that capability profiles carry the differences — but that answer has to survive real systems.
 
-**Reversible boundaries could be theoretical.** Merging and splitting nodes is only cheap while node identity has not leaked into anything durable — lineage records, persisted state, external correlation, human task queues. If it leaks, every boundary change becomes a migration.
+**Reversible boundaries could be theoretical.** Moving boundaries stays cheap only while durable records — lineage, persisted state, external correlation, human task queues — key off contract and execution identity rather than the topology that produced them. If they come to depend on which node did the work, every boundary change becomes a migration.
 
-## What it looks like
-
-A purchase order.
-
-A deterministic pricing workflow computes terms and requests a draft from an LLM agent. The agent produces contract language and requests human approval. The approval comes back three days later, after two deploys. The approved order settles against an external ERP that knows nothing about Arvo.
-
-Four participants. Four completely different execution characteristics — deterministic, nondeterministic, human-latency, foreign. One composition model, no privileged control path, and a three-day gap that has to survive a deployment.
-
-Later, pricing and terms-drafting turn out to belong together, and are sealed behind a single `terms` node. Order intake always addressed the pricing contract, and the sealed node continues to implement it, so nothing calling in changes. The drafting contract — which only pricing ever addressed — disappears from the graph entirely.
-
-That is the rule, not a special case: decomposition behind a boundary is always invisible to callers, and convergence is invisible exactly when the contracts being absorbed had no external consumers. Had another team been calling drafting directly, sealing it would have been a breaking change for them.
+**Static capability declaration could age badly.** A handler declares every contract it may talk to before it runs. That buys explicit, analysable effects. It costs runtime extensibility: a capability registered after deployment needs a redeploy, and discovery-style tool acquisition is out. If agent composition standardises on runtime discovery, this is the wrong side of that trade.
 
 ## Next
 
-- [ADR-000 — Arvo System Identity and Architectural Principles](adr/000-arvo-system-identity-and-architectural-principles.md)
+- [ADR-000 — Arvo System Identity and Architectural Invariants](adr/000-arvo-system-identity-and-architectural-principles.md)
 - [https://www.arvo.land/](https://www.arvo.land/)

--- a/docs/vision.md
+++ b/docs/vision.md
@@ -1,0 +1,50 @@
+# Arvo — Vision
+
+> Non-normative. This document explains why Arvo exists and what it is betting on.
+> The binding architectural commitments are recorded in
+> [ADR-000](adr/000-arvo-system-identity-and-architectural-principles.md).
+
+## What Arvo is
+
+Arvo is a portable application model for event-driven systems. It defines how independently built participants — conventional handlers, deterministic workflows, AI agents, human approvals, external systems — compose through versioned contracts and events.
+
+Arvo does not execute that model. Infrastructure adapters do.
+
+## The bet
+
+**One composition model, at any scale.** Application logic is becoming a mixture. A single business process now spans deterministic code, a nondeterministic agent, a human who takes three days to respond, and a system you do not control. No execution engine is going to own that mixture. Arvo bets that the layer worth standardising is therefore composition, not execution — and that choreography, with orchestration expressed as an ordinary participant inside it rather than as a privileged conductor, is the model that spans all of it.
+
+**Boundaries you can move.** Composition is closed: any group of nodes can be sealed behind a single contract and presented as one node. That works in both directions. Several nodes converge into one when you want less surface; one node bifurcates into several when a seam turns out to be real. Node granularity becomes a reversible design decision rather than an architectural commitment, so being wrong about service boundaries early is cheap — in a way it is not when the service boundary is also the deployment boundary and the codebase boundary.
+
+The unit of reuse follows from this. You do not import a capability, you address its contract. What is behind it may be TypeScript, may be Python, may be a queue a human works from. Consumers cannot tell and do not need to.
+
+**It outlives the engine you picked.** Application semantics stay portable across infrastructure adapters. The first two legs are what you use Arvo for; this is what keeps them from expiring when the platform underneath changes.
+
+## How this could be wrong
+
+Worth stating plainly, so it can be judged later.
+
+**Portability could turn out to be free.** If durable execution engines converge on a shared open programming model, the independence Arvo buys stops being worth paying for.
+
+**Choreography's cost might not be paid off.** The standing objection is that in a choreographed system the process exists nowhere and nobody can see it. Arvo's answer is that declared contracts make the possible edges statically visible and lineage makes the actual edges visible after the fact. If that answer does not hold at fifty nodes in practice, teams will retreat to central orchestrators and the universal composition claim fails.
+
+**Orchestrated choreography could prove too expensive.** A coordinating node with no privileged control path also has no cheap cancellation, no cheap timeout, and no cheap way to abort everything downstream. All of it must be modelled as events. If that is ergonomically painful enough, people will want the back channel — and the model forbids it.
+
+**Uniformity could be lowest-common-denominator in disguise.** Arvo rejects workflow-engine abstraction layers for flattening engines to a common case. The same charge can be aimed at one composition model serving deterministic workflows, agents, and humans alike. The answer is that Arvo composes rather than normalizes, and that capability profiles carry the differences — but that answer has to survive contact with real systems.
+
+**Reversible boundaries could be theoretical.** Merging and splitting nodes is only cheap while node identity has not leaked into anything durable — lineage records, persisted state, external correlation, human task queues. If it leaks, every boundary change becomes a migration.
+
+## What it looks like
+
+A purchase order.
+
+A deterministic pricing workflow computes terms and requests a draft from an LLM agent. The agent produces contract language and requests human approval. The approval comes back three days later, after two deploys. The approved order settles against an external ERP that knows nothing about Arvo.
+
+Four participants. Four completely different execution characteristics — deterministic, nondeterministic, human-latency, foreign. One composition model, no privileged control path, and a three-day gap that has to survive a deployment.
+
+Later, pricing and terms-drafting turn out to belong together and are sealed behind a single `terms` contract. Nothing calling them changes.
+
+## Next
+
+- [ADR-000 — Arvo System Identity and Architectural Principles](adr/000-arvo-system-identity-and-architectural-principles.md)
+- [https://www.arvo.land/](https://www.arvo.land/)

--- a/docs/vision.md
+++ b/docs/vision.md
@@ -42,7 +42,9 @@ A deterministic pricing workflow computes terms and requests a draft from an LLM
 
 Four participants. Four completely different execution characteristics — deterministic, nondeterministic, human-latency, foreign. One composition model, no privileged control path, and a three-day gap that has to survive a deployment.
 
-Later, pricing and terms-drafting turn out to belong together and are sealed behind a single `terms` contract. Nothing calling them changes.
+Later, pricing and terms-drafting turn out to belong together, and are sealed behind a single `terms` node. Order intake always addressed the pricing contract, and the sealed node continues to implement it, so nothing calling in changes. The drafting contract — which only pricing ever addressed — disappears from the graph entirely.
+
+That is the rule, not a special case: decomposition behind a boundary is always invisible to callers, and convergence is invisible exactly when the contracts being absorbed had no external consumers. Had another team been calling drafting directly, sealing it would have been a breaking change for them.
 
 ## Next
 


### PR DESCRIPTION
Adds the foundational ADR for the Arvo ecosystem and the vision document that
motivates it. Documentation only — no code changes.

## What's here

- `docs/adr/000-arvo-system-identity-and-architectural-principles.md` — defines
  **AAM 1**, the Arvo Application Model: a versioned, language-independent
  application model, distinct from the version of any package implementing it.
  `arvo-core` v4 is its first TypeScript implementation.
- `docs/vision.md` — non-normative. Why Arvo exists, what it is betting on, and
  the six conditions under which that bet loses.
- `docs/adr/README.md` — ADR index and status conventions.
- `README.md` — links to both.

The split is deliberate: the vision persuades and can be argued with, the ADR
binds and must be conformed to. Neither is a spec.

## The decision

Three claims, answering three problems stated in the Context:

1. **Choreography is the universal composition model.** Handlers, deterministic
   workflows, agents, humans, and external systems are all nodes. None is an
   exception. Orchestration is a pattern inside choreography — a coordinating
   node with no privileged control path.
2. **Composition is closed.** Any set of composed nodes can be presented as one
   node behind one contract, in both directions, with no additional primitive.
   Node granularity becomes a reversible design decision rather than an
   architectural commitment.
3. **The model is portable.** Composition and handler lifecycle semantics do not
   depend on the broker, database, platform, scheduler, or engine an adapter
   selects. Portability of a handler's internal logic is explicitly not claimed.

## What reviewers should push on

These are the binding commitments. Everything else is deferred.

- **AAM membership lists** are declared exhaustive as of this ADR, amendable by
  explicit reference from downstream ADRs. Expect the first few ADRs to amend
  them.
- **CloudEvent transformability binds AAM 1**; whether the transformation is
  lossless and bidirectional is left to the ArvoEvent ADR.
- **ArvoEvents are JSON-serializable.** Load-bearing for claim 1 — participation
  must not require codegen, a schema registry, or a shared runtime.
- **Static capability closure.** A handler declares every contract it may talk
  to before any execution instance begins. Buys analysable effects, costs
  runtime extensibility. Called out as a failure condition in the vision.
- **No live implementation dependency may be relied upon across a suspension
  boundary.** Within an execution slice, internals are unconstrained.
- **Runtime validation is required** at trust boundaries; compile-time types
  cannot substitute for it.
- **Three standing constraints** on deferred decisions, in `Applying This ADR` —
  the load-bearing one being that durable records must key off contract and
  execution identity rather than node identity, since reversible composition
  depends on it.

## Deliberately not here

Sixteen deferred decisions, each requiring its own ADR. Most consequential:
cancellation and compensation semantics; timers, deadlines, and time semantics;
delivery ordering scope; execution capability profiles; adapter conformance;
cross-language compatibility; and the formal boundary of an "Arvo application."

`Applying This ADR` defines what every downstream ADR must state, so ADR-001
onward have a template to conform to.

## Status

**Proposed**, not Accepted. Per the Governance section it should only be marked
Accepted once review confirms it describes AAM rather than the incidental
details of the current TypeScript implementation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
